### PR TITLE
feat: Adiciona suporte a CORS no servidor

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,8 +1,14 @@
 const express = require('express');
 require('dotenv').config();
 const bodyParser = require('body-parser');
+const cors = require('cors');
 const { sequelize } = require('./models');
 const app = express();
+
+app.use(cors({
+  origin: 'http://localhost:5173'
+}));
+
 app.use(bodyParser.json());
 
 app.use('/usuarios', require('./routes/usuarios'));

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "bcryptjs": "^3.0.2",
         "body-parser": "^1.20.2",
+        "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2",
@@ -397,6 +398,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1215,6 +1229,15 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "bcryptjs": "^3.0.2",
     "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",


### PR DESCRIPTION
## ✨ Adiciona suporte a CORS no backend

### 📌 Descrição

Este PR adiciona suporte ao **CORS (Cross-Origin Resource Sharing)** na aplicação backend, permitindo que o frontend (rodando em `http://localhost:5173`) se comunique com a API durante o desenvolvimento.

### ✅ Alterações realizadas

- Instalação da dependência `cors` (`^2.8.5`);
- Inclusão do `cors` no `app.js`;
- Configuração do middleware `cors` para permitir requisições da origem `http://localhost:5173`.

### 🧪 Como testar

1. Inicie o backend com `npm start` ou comando equivalente;
2. Inicie o frontend no endereço `http://localhost:5173`;
3. Verifique se as requisições para o backend são feitas sem erros de CORS.

### 📦 Dependências adicionadas

- [`cors`](https://www.npmjs.com/package/cors) — versão `2.8.5`
