### PR TITLE
feat: adiciona relacionamento entre Evento e Ingresso, incluindo Even…

### DIFF
--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -25,10 +25,14 @@ const Avaliacoes = require('./avaliacoes')(sequelize);
 // Evento.belongsToMany(Usuario, { through: Ingresso });
 // Removido devido ao motivo que isso acima não criava a pk pro ingresso que era algo necessário 
 
+Evento.hasMany(Ingresso, { foreignKey: 'EventoId' });
+Ingresso.belongsTo(Evento, { foreignKey: 'EventoId' });
+
+
 Ingresso.belongsTo(Usuario);
-Ingresso.belongsTo(Evento);
+// Ingresso.belongsTo(Evento);
 Usuario.hasMany(Ingresso);
-Evento.hasMany(Ingresso);
+// Evento.hasMany(Ingresso);
 
 
 Usuario.hasMany(Compras);

--- a/backend/models/ingresso.js
+++ b/backend/models/ingresso.js
@@ -11,6 +11,16 @@ module.exports = (sequelize) => {
     tipoingresso: DataTypes.STRING,
     preco: DataTypes.DECIMAL, 
     quantidadeTotal: DataTypes.INTEGER, 
-    quantidadeDisponivel: DataTypes.INTEGER
+    quantidadeDisponivel: DataTypes.INTEGER,
+    EventoId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Eventos',
+        key: 'id'
+      },
+      onDelete: 'CASCADE'
+    }
+    
   });
 };


### PR DESCRIPTION
# PR: Adição de Relacionamento Evento-Ingresso

## Descrição
Adiciona a foreign key `EventoId` no modelo Ingresso e estabelece relacionamentos explícitos entre Evento e Ingresso.

## Principais mudanças:
- ✅ Adicionada FK `EventoId` obrigatória no modelo Ingresso
- 🔄 Configurado relacionamento 1:N bidirecional (`Evento.hasMany`/`Ingresso.belongsTo`)
- 🗑️ Implementado `onDelete: CASCADE` para remoção automática de ingressos vinculados

## Impacto:
- Garante integridade referencial no banco
- Simplifica queries de associação
- Melhora consistência dos dados