### PR TITLE
feat: filtra eventos por OrganizadorId

### DIFF
--- a/backend/controllers/eventosController.js
+++ b/backend/controllers/eventosController.js
@@ -1,8 +1,20 @@
 const { Evento } = require('../models');
 
 exports.getAllEventos = async (req, res)=> {
-    const eventos = await Evento.findAll(); 
-    res.json(eventos); 
+    try {
+    const { OrganizadorId } = req.query;
+
+    const where = {};
+    if (OrganizadorId) {
+      where.OrganizadorId = OrganizadorId;
+    }
+
+    const eventos = await Evento.findAll({ where });
+    res.json(eventos);
+  } catch (error) {
+    console.error("Erro ao buscar eventos:", error);
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
 }; 
 
 exports.getEventoById = async (req,res)=> {

--- a/backend/models/evento.js
+++ b/backend/models/evento.js
@@ -13,7 +13,7 @@ module.exports = (sequelize) => {
     categoria: DataTypes.STRING,
     quantidadeingresso: DataTypes.INTEGER,
     //OrganizadoID(UsuarioID PK ) definir no indexJS 
-    status: DataTypes.STRING
-
+    status: DataTypes.STRING,
+    OrganizadorId: DataTypes.INTEGER
   });
 };

--- a/frontend/src/components/admin/AdminComponent.vue
+++ b/frontend/src/components/admin/AdminComponent.vue
@@ -751,6 +751,10 @@
   
   <script>
   import axios from 'axios';
+  import { jwtDecode } from 'jwt-decode';
+  const token = localStorage.getItem('token');
+  const decoded = jwtDecode(token);
+  const organizadorId = decoded.id
   export default {
     name: 'AdminPainel',
     data() {
@@ -810,41 +814,42 @@
   },
     methods: {
       async fetchEvents() {
-      this.isLoading = true;
-      try {
-        const eventsResponse = await fetch("http://localhost:3000/eventos");
-        if (!eventsResponse.ok) throw new Error("Erro ao carregar eventos");
-        const eventos = await eventsResponse.json();
+        this.isLoading = true;
+        try {
+          const eventsResponse = await fetch(`http://localhost:3000/eventos?OrganizadorId=${organizadorId}`);
+          // const eventsResponse = await fetch("http://localhost:3000/eventos");
+          if (!eventsResponse.ok) throw new Error("Erro ao carregar eventos");
+          const eventos = await eventsResponse.json();
 
-        const ingressosResponse = await fetch(
-          "http://localhost:3000/ingressos"
-        );
-        if (!ingressosResponse.ok)
-          throw new Error("Erro ao carregar ingressos");
-        const ingressos = await ingressosResponse.json();
-
-        this.events = eventos.map((evento) => {
-          const ingressosDoEvento = ingressos.filter(
-            (ingresso) => ingresso.EventoId === evento.id
+          const ingressosResponse = await fetch(
+            "http://localhost:3000/ingressos"
           );
-          return {
-            ...evento,
-            ingressos: ingressosDoEvento,
-            precoMinimo:
-              ingressosDoEvento.length > 0
-                ? Math.min(...ingressosDoEvento.map((i) => parseFloat(i.preco)))
-                : 0,
-          };
-        });
+          if (!ingressosResponse.ok)
+            throw new Error("Erro ao carregar ingressos");
+          const ingressos = await ingressosResponse.json();
 
-        this.error = null;
-      } catch (err) {
-        console.error("Erro na API:", err);
-        this.error = "Não foi possível carregar os dados";
-      } finally {
-        this.isLoading = false;
-      }
-    },
+          this.events = eventos.map((evento) => {
+            const ingressosDoEvento = ingressos.filter(
+              (ingresso) => ingresso.EventoId === evento.id
+            );
+            return {
+              ...evento,
+              ingressos: ingressosDoEvento,
+              precoMinimo:
+                ingressosDoEvento.length > 0
+                  ? Math.min(...ingressosDoEvento.map((i) => parseFloat(i.preco)))
+                  : 0,
+            };
+          });
+
+          this.error = null;
+        } catch (err) {
+          console.error("Erro na API:", err);
+          this.error = "Não foi possível carregar os dados";
+        } finally {
+          this.isLoading = false;
+        }
+      },
 
     formatDate(dateString) {
       const options = { day: "2-digit", month: "long", year: "numeric" };
@@ -918,7 +923,7 @@
         categoria: this.newEvent.categoria,
         quantidadeingresso: parseInt(this.newEvent.quantidadeingresso) || 0,
         status: this.newEvent.status,
-        organizadorId: parseInt(this.newEvent.organizadorId)
+        OrganizadorId: organizadorId
       };
 
       const response = await axios.post('http://localhost:3000/eventos', eventData);


### PR DESCRIPTION
# Suporte a filtragem de eventos por OrganizadorId

## Descrição

Adicionei suporte para utilizar o `OrganizadorId` nas operações de listagem e criação de eventos, garantindo que cada organizador visualize e crie apenas seus próprios eventos.

## Alterações realizadas

- **Backend (`eventosController.js`)**
  - A rota `GET /eventos` agora aceita o parâmetro de query `OrganizadorId` para retornar apenas os eventos vinculados ao organizador.
  - Adicionada cláusula `where` dinâmica para filtrar pelo `OrganizadorId`.

- **Model (`evento.js`)**
  - Incluído o campo `OrganizadorId` no modelo `Evento`.

- **Frontend (`AdminComponent.vue`)**
  - Extraído o `OrganizadorId` do token JWT no `localStorage` usando `jwt-decode`.
  - Enviado `OrganizadorId` na query string da requisição de listagem de eventos.
  - Incluído `OrganizadorId` no corpo da requisição de criação de evento.
